### PR TITLE
Add AccessControlEnumerable library from OpenZeppelin

### DIFF
--- a/contracts/BridgingManager.sol
+++ b/contracts/BridgingManager.sol
@@ -3,11 +3,11 @@
 
 pragma solidity 0.8.10;
 
-import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 
 /// @author psirex
 /// @notice Contains administrative methods to retrieve and control the state of the bridging
-contract BridgingManager is AccessControl {
+contract BridgingManager is AccessControlEnumerable {
     /// @dev Stores the state of the bridging
     /// @param isInitialized Shows whether the contract is initialized or not
     /// @param isDepositsEnabled Stores the state of the deposits


### PR DESCRIPTION
Lido [recommendation](https://docs.lido.fi/token-guides/wsteth-bridging-guide/#recommendations) R11 prefer the standard OpenZeppelin ACL contract and its [enumerable version](https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControlEnumerable) over non-enumerable versions. 

Therefore `AccessControl` is replaced with `AccessControlEnumerable` in BridgingManager.sol